### PR TITLE
Change float -> CGFloat

### DIFF
--- a/Boxes/BoxesPalette.m
+++ b/Boxes/BoxesPalette.m
@@ -16,7 +16,7 @@
 
   if([(id<IB>)NSApp isTestingInterface] == NO)
     {
-      float dot_dash[] = {1.0, 1.0};
+      CGFloat dot_dash[] = {1.0, 1.0};
       NSGraphicsContext *ctxt = GSCurrentContext();
 
       // Draw a green box;


### PR DESCRIPTION
Otherwise you get the following warning on 64-bit systems:

    BoxesPalette.m: In function ‘-[GSTable(GormDrawingExtension) drawRect:]’:
    BoxesPalette.m:25:24: warning: passing argument 2 of ‘DPSsetdash’ from incompatible pointer type [-Wincompatible-pointer-types]
       DPSsetdash(ctxt, dot_dash, 4, 0.0);
                        ^~~~~~~~
    In file included from /usr/local/include/AppKit/PSOperators.h:30:0,
                 from /usr/local/include/AppKit/AppKit.h:199,
                 from BoxesPalette.m:3:
    /usr/local/include/AppKit/DPSOperators.h:822:1: note: expected ‘const CGFloat * {aka const double *}’ but argument is of type ‘float *’
     DPSsetdash(GSCTXT *ctxt, const CGFloat* pat, NSInteger size, CGFloat offset)
     ^~~~~~~~~~